### PR TITLE
Issue #17 update numeric assertions for dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,19 @@ assert_that(today).is_equal_to_ignoring_time(today_5h)
 assert_that(today).is_equal_to(today)
 ```
 
+You can use these numeric assertions on dates:
+
+```
+middle = today - datetime.timedelta(hours=12)
+hours_24 = datetime.timedelta(hours=24)
+
+assert_that(today).is_greater_than(yesterday)
+assert_that(yesterday).is_less_than(today)
+assert_that(middle).is_between(yesterday, today)
+#note that the tolerance must be a datetime.timedelta object
+assert_that(yesterday).is_close_to(today, hours_24)
+```
+
 Currently, `assertpy` only supports dates via the `datetime` type.
 
 ### Files

--- a/assertpy/assertpy.py
+++ b/assertpy/assertpy.py
@@ -183,9 +183,9 @@ class AssertionBuilder(object):
         """Asserts that val is numeric and is greater than other."""
         if type(self.val) is complex or type(other) is complex:
             raise TypeError('ordering is not defined for complex numbers')
-        if type(self.val) not in (int, float, long):
+        if type(self.val) not in (int, float, long, datetime.datetime):
             raise TypeError('val is not numeric')
-        if type(other) not in (int, float, long):
+        if type(other) not in (int, float, long, datetime.datetime):
             raise TypeError('given arg must be numeric')
         if self.val <= other:
             raise AssertionError('Expected <%s> to be greater than <%s>, but was not.' % (self.val, other))
@@ -195,9 +195,9 @@ class AssertionBuilder(object):
         """Asserts that val is numeric and is less than other."""
         if type(self.val) is complex or type(other) is complex:
             raise TypeError('ordering is not defined for complex numbers')
-        if type(self.val) not in (int, float, long):
+        if type(self.val) not in (int, float, long, datetime.datetime):
             raise TypeError('val is not numeric')
-        if type(other) not in (int, float, long):
+        if type(other) not in (int, float, long, datetime.datetime):
             raise TypeError('given arg must be numeric')
         if self.val >= other:
             raise AssertionError('Expected <%s> to be less than <%s>, but was not.' % (self.val, other))
@@ -207,11 +207,11 @@ class AssertionBuilder(object):
         """Asserts that val is numeric and is between low and high."""
         if type(self.val) is complex or type(low) is complex or type(high) is complex:
             raise TypeError('ordering is not defined for complex numbers')
-        if type(self.val) not in (int, float, long):
+        if type(self.val) not in (int, float, long, datetime.datetime):
             raise TypeError('val is not numeric')
-        if type(low) not in (int, float, long):
+        if type(low) not in (int, float, long, datetime.datetime):
             raise TypeError('given low arg must be numeric')
-        if type(high) not in (int, float, long):
+        if type(high) not in (int, float, long, datetime.datetime):
             raise TypeError('given high arg must be numeric')
         if low > high:
             raise ValueError('given low arg must be less than given high arg')
@@ -223,13 +223,13 @@ class AssertionBuilder(object):
         """Asserts that val is numeric and is close to other within tolerance."""
         if type(self.val) is complex or type(other) is complex or type(tolerance) is complex:
             raise TypeError('ordering is not defined for complex numbers')
-        if type(self.val) not in (int, float, long):
+        if type(self.val) not in (int, float, long, datetime.datetime):
             raise TypeError('val is not numeric')
-        if type(other) not in (int, float, long):
+        if type(other) not in (int, float, long, datetime.datetime):
             raise TypeError('given arg must be numeric')
-        if type(tolerance) not in (int, float, long):
+        if type(tolerance) not in (int, float, long, datetime.timedelta):
             raise TypeError('given tolerance arg must be numeric')
-        if tolerance < 0:
+        if type(tolerance) in (int, float, long) and tolerance < 0:
             raise ValueError('given tolerance arg must be positive')
         if self.val < (other-tolerance) or self.val > (other+tolerance):
             raise AssertionError('Expected <%s> to be close to <%s> within tolerance <%s>, but was not.' % (self.val, other, tolerance))


### PR DESCRIPTION
Updated these functions:

```py
assert_that(123).is_greater_than(100)
assert_that(123).is_less_than(200)
assert_that(123).is_between(100, 200)
assert_that(123).is_close_to(100, 25)
```

to work with `datetime` objects.  Note that `is_close_to()` requires `datetime.timedelta` for the tolerance arg.