### PR TITLE
Feature - is_same_as/is_not_same_as

### DIFF
--- a/assertpy/assertpy.py
+++ b/assertpy/assertpy.py
@@ -694,6 +694,18 @@ class AssertionBuilder(object):
             self._err('Expected file <%s> to be a child of <%s>, but was not.' % (val_abspath, parent_abspath))
         return self
 
+    def is_same_as(self, other):
+        """Asserts that the val is the same as the 'other' object being compared to."""
+        if self.val is not other:
+            self._err('Expected <%s> to be identical to <%s>, but was not.' % (self.val, other))
+        return self
+
+    def is_not_same_as(self, other):
+        """Asserts that the val is the same as the 'other' object being compared to."""
+        if self.val is other:
+            self._err('Expected <%s> to be not identical to <%s>, but was not.' % (self.val, other))
+        return self
+
 ### collection of objects assertions ###
     def extract(self, *names):
         """Asserts that val is collection, then extracts the named properties or named zero-arg methods into a list (or list of tuples if multiple names are given)."""

--- a/tests/test_same_as.py
+++ b/tests/test_same_as.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2015, Activision Publishing, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from assertpy import assert_that, fail
+
+
+class TestSameAs(object):
+
+    def test_is_same_as(self):
+        test_obj = object()
+        assert_that(test_obj).is_same_as(test_obj)
+
+    def test_is_same_as_failure(self):
+        try:
+            test_obj = object()
+            other_obj = object()
+            assert_that(test_obj).is_same_as(other_obj)
+            fail('should have raised error')
+        except AssertionError as ex:
+            assert_that(str(ex))\
+                .matches('Expected <<object [^>]+>> to be identical to <<object [^>]+>>, but was not.')
+
+    def test_is_not_same_as(self):
+        test_obj = object()
+        other_obj = object()
+        assert_that(test_obj).is_not_same_as(other_obj)
+        assert_that(test_obj).is_not_same_as(1)
+        assert_that(test_obj).is_not_same_as(True)
+        assert_that(1).is_not_same_as(2)
+        assert_that({}).is_not_same_as([])
+        assert_that({}).is_not_same_as({})
+        assert_that([]).is_not_same_as([])
+
+    def test_is_not_none_failure(self):
+        for test_obj in [object(), None, 1, 2, True]:
+            try:
+                assert_that(test_obj).is_not_same_as(test_obj)
+                fail('should have raised error')
+            except AssertionError as ex:
+                assert_that(str(ex))\
+                    .matches('Expected <.+> to be not identical to <.+>, but was not.')


### PR DESCRIPTION
Commit Message:

Added two new methods to the AssertionBuilder class, is_same_as(other_thing) and is_not_same_as(other_thing). These methods do identity comparison (via is or is not), which did not appear to be present in the library. Tests for these methods were added in as tests/test_same_as.py

------------------------------------------------

So just wanted to say, after being present for your talk at the Boulder Python Meetup group on assertpy, I was really impressed with this library, and started to use it in some of my own testing. Thanks for making this open source! One thing that I did not see (and now kind of need), is the ability to check the reference of an object in relation to another, so I wrote this commit to address this (and added some tests for basic coverage). Hopefully this looks good, anything further I need to do to make it production quality worthy, or am I duplicating functionality I missed somewhere else?