### PR TITLE
scaleable comparison checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ dist
 
 # mac
 .DS_Store
+
+# IDE
+/.idea

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -178,7 +178,7 @@ class TestDate(object):
             assert_that(self.d1).is_greater_than(123)
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('given arg must be datetime, but was <int>')
+            assert_that(str(ex)).is_equal_to('given arg must be <datetime>, but was <int>')
 
     def test_is_greater_than_or_equal_to(self):
         assert_that(self.d1).is_greater_than_or_equal_to(self.d1)
@@ -196,7 +196,7 @@ class TestDate(object):
             assert_that(self.d1).is_greater_than_or_equal_to(123)
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('given arg must be datetime, but was <int>')
+            assert_that(str(ex)).is_equal_to('given arg must be <datetime>, but was <int>')
 
     def test_is_less_than(self):
         d2 = datetime.datetime.today()
@@ -215,7 +215,7 @@ class TestDate(object):
             assert_that(self.d1).is_less_than(123)
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('given arg must be datetime, but was <int>')
+            assert_that(str(ex)).is_equal_to('given arg must be <datetime>, but was <int>')
 
     def test_is_less_than_or_equal_to(self):
         assert_that(self.d1).is_less_than_or_equal_to(self.d1)
@@ -233,7 +233,7 @@ class TestDate(object):
             assert_that(self.d1).is_less_than_or_equal_to(123)
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('given arg must be datetime, but was <int>')
+            assert_that(str(ex)).is_equal_to('given arg must be <datetime>, but was <int>')
 
     def test_is_between(self):
         d2 = datetime.datetime.today()
@@ -254,7 +254,7 @@ class TestDate(object):
             assert_that(self.d1).is_between(123, 456)
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('given low arg must be datetime, but was <int>')
+            assert_that(str(ex)).is_equal_to('given low arg must be <datetime>, but was <int>')
 
     def test_is_between_bad_arg2_type_failure(self):
         try:
@@ -262,7 +262,7 @@ class TestDate(object):
             assert_that(self.d1).is_between(d2, 123)
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('given high arg must be datetime, but was <int>')
+            assert_that(str(ex)).is_equal_to('given high arg must be <datetime>, but was <datetime>')
 
     def test_is_close_to(self):
         d2 = datetime.datetime.today()
@@ -291,3 +291,95 @@ class TestDate(object):
         except TypeError as ex:
             assert_that(str(ex)).is_equal_to('given tolerance arg must be timedelta, but was <int>')
 
+class TestTimedelta(object):
+
+    def setup(self):
+        self.t1 = datetime.timedelta(seconds=60)
+
+    def test_is_greater_than(self):
+        d2 = datetime.timedelta(seconds=120)
+        assert_that(d2).is_greater_than(self.t1)
+
+    def test_is_greater_than_failure(self):
+        try:
+            t2 = datetime.timedelta(seconds=90)
+            assert_that(self.t1).is_greater_than(t2)
+            fail('should have raised error')
+        except AssertionError as ex:
+            assert_that(str(ex)).matches('Expected <\d{1,2}:\d{2}:\d{2}> to be greater than <\d{1,2}:\d{2}:\d{2}>, but was not.')
+
+    def test_is_greater_than_bad_arg_type_failure(self):
+        try:
+            assert_that(self.t1).is_greater_than(123)
+            fail('should have raised error')
+        except TypeError as ex:
+            assert_that(str(ex)).is_equal_to('given arg must be <timedelta>, but was <int>')
+
+    def test_is_greater_than_or_equal_to(self):
+        assert_that(self.t1).is_greater_than_or_equal_to(self.t1)
+
+    def test_is_greater_than_or_equal_to_failure(self):
+        try:
+            t2 = datetime.timedelta(seconds=90)
+            assert_that(self.t1).is_greater_than_or_equal_to(t2)
+            fail('should have raised error')
+        except AssertionError as ex:
+            assert_that(str(ex)).matches('Expected <\d{1,2}:\d{2}:\d{2}> to be greater than or equal to <\d{1,2}:\d{2}:\d{2}>, but was not.')
+
+    def test_is_greater_than_or_equal_to_bad_arg_type_failure(self):
+        try:
+            assert_that(self.t1).is_greater_than_or_equal_to(123)
+            fail('should have raised error')
+        except TypeError as ex:
+            assert_that(str(ex)).is_equal_to('given arg must be <timedelta>, but was <int>')
+
+    def test_is_less_than(self):
+        t2 = datetime.timedelta(seconds=90)
+        assert_that(self.t1).is_less_than(t2)
+
+    def test_is_less_than_failure(self):
+        try:
+            t2 = datetime.timedelta(seconds=90)
+            assert_that(t2).is_less_than(self.t1)
+            fail('should have raised error')
+        except AssertionError as ex:
+            assert_that(str(ex)).matches('Expected <\d{1,2}:\d{2}:\d{2}> to be less than <\d{1,2}:\d{2}:\d{2}>, but was not.')
+
+    def test_is_less_than_bad_arg_type_failure(self):
+        try:
+            assert_that(self.t1).is_less_than(123)
+            fail('should have raised error')
+        except TypeError as ex:
+            assert_that(str(ex)).is_equal_to('given arg must be <timedelta>, but was <int>')
+
+    def test_is_less_than_or_equal_to(self):
+        assert_that(self.t1).is_less_than_or_equal_to(self.t1)
+
+    def test_is_less_than_or_equal_to_failure(self):
+        try:
+            t2 = datetime.timedelta(seconds=90)
+            assert_that(t2).is_less_than_or_equal_to(self.t1)
+            fail('should have raised error')
+        except AssertionError as ex:
+            assert_that(str(ex)).matches('Expected <\d{1,2}:\d{2}:\d{2}> to be less than or equal to <\d{1,2}:\d{2}:\d{2}>, but was not.')
+
+    def test_is_less_than_or_equal_to_bad_arg_type_failure(self):
+        try:
+            assert_that(self.t1).is_less_than_or_equal_to(123)
+            fail('should have raised error')
+        except TypeError as ex:
+            assert_that(str(ex)).is_equal_to('given arg must be <timedelta>, but was <int>')
+
+    def test_is_between(self):
+        d2 = datetime.timedelta(seconds=90)
+        d3 = datetime.timedelta(seconds=120)
+        assert_that(d2).is_between(self.t1, d3)
+
+    def test_is_between_failure(self):
+        try:
+            d2 = datetime.timedelta(seconds=30)
+            d3 = datetime.timedelta(seconds=40)
+            assert_that(self.t1).is_between(d2, d3)
+            fail('should have raised error')
+        except AssertionError as ex:
+            assert_that(str(ex)).matches('Expected <\d{1,2}:\d{2}:\d{2}> to be between <\d{1,2}:\d{2}:\d{2}> and <\d{1,2}:\d{2}:\d{2}>, but was not.')

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -88,21 +88,21 @@ class TestNumbers(object):
             assert_that(1 + 2j).is_greater_than(0)
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('ordering is not defined for complex numbers')
+            assert_that(str(ex)).is_equal_to('ordering is not defined for type <complex>')
 
     def test_is_greater_than_bad_value_type_failure(self):
         try:
             assert_that('foo').is_greater_than(0)
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('val is not numeric or datetime')
+            assert_that(str(ex)).is_equal_to('ordering is not defined for type <str>')
 
     def test_is_greater_than_bad_arg_type_failure(self):
         try:
             assert_that(123).is_greater_than('foo')
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('given arg must be numeric')
+            assert_that(str(ex)).is_equal_to('given arg must be a number, but was <str>')
 
     def test_is_greater_than_or_equal_to(self):
         assert_that(123).is_greater_than_or_equal_to(100)
@@ -123,21 +123,21 @@ class TestNumbers(object):
             assert_that(1 + 2j).is_greater_than_or_equal_to(0)
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('ordering is not defined for complex numbers')
+            assert_that(str(ex)).is_equal_to('ordering is not defined for type <complex>')
 
     def test_is_greater_than_or_equal_to_bad_value_type_failure(self):
         try:
             assert_that('foo').is_greater_than_or_equal_to(0)
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('val is not numeric or datetime')
+            assert_that(str(ex)).is_equal_to('ordering is not defined for type <str>')
 
     def test_is_greater_than_or_equal_to_bad_arg_type_failure(self):
         try:
             assert_that(123).is_greater_than_or_equal_to('foo')
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('given arg must be numeric')
+            assert_that(str(ex)).is_equal_to('given arg must be a number, but was <str>')
 
     def test_is_less_than(self):
         assert_that(123).is_less_than(1000)
@@ -157,21 +157,21 @@ class TestNumbers(object):
             assert_that(1 + 2j).is_less_than(0)
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('ordering is not defined for complex numbers')
+            assert_that(str(ex)).is_equal_to('ordering is not defined for type <complex>')
 
     def test_is_less_than_bad_value_type_failure(self):
         try:
             assert_that('foo').is_less_than(0)
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('val is not numeric or datetime')
+            assert_that(str(ex)).is_equal_to('ordering is not defined for type <str>')
 
     def test_is_less_than_bad_arg_type_failure(self):
         try:
             assert_that(123).is_less_than('foo')
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('given arg must be numeric')
+            assert_that(str(ex)).is_equal_to('given arg must be a number, but was <str>')
 
     def test_is_less_than_or_equal_to(self):
         assert_that(123).is_less_than_or_equal_to(1000)
@@ -192,21 +192,21 @@ class TestNumbers(object):
             assert_that(1 + 2j).is_less_than_or_equal_to(0)
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('ordering is not defined for complex numbers')
+            assert_that(str(ex)).is_equal_to('ordering is not defined for type <complex>')
 
     def test_is_less_than_or_equal_to_bad_value_type_failure(self):
         try:
             assert_that('foo').is_less_than_or_equal_to(0)
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('val is not numeric or datetime')
+            assert_that(str(ex)).is_equal_to('ordering is not defined for type <str>')
 
     def test_is_less_than_or_equal_to_bad_arg_type_failure(self):
         try:
             assert_that(123).is_less_than_or_equal_to('foo')
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('given arg must be numeric')
+            assert_that(str(ex)).is_equal_to('given arg must be a number, but was <str>')
 
     def test_is_positive(self):
         assert_that(1).is_positive()
@@ -246,28 +246,28 @@ class TestNumbers(object):
             assert_that(1 + 2j).is_between(0,1)
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('ordering is not defined for complex numbers')
+            assert_that(str(ex)).is_equal_to('ordering is not defined for type <complex>')
 
     def test_is_between_bad_value_type_failure(self):
         try:
             assert_that('foo').is_between(0,1)
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('val is not numeric or datetime')
+            assert_that(str(ex)).is_equal_to('ordering is not defined for type <str>')
 
     def test_is_between_low_arg_type_failure(self):
         try:
             assert_that(123).is_between('foo',1)
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('given low arg must be numeric')
+            assert_that(str(ex)).is_equal_to('given low arg must be numeric, but was <str>')
 
     def test_is_between_high_arg_type_failure(self):
         try:
             assert_that(123).is_between(0,'foo')
             fail('should have raised error')
         except TypeError as ex:
-            assert_that(str(ex)).is_equal_to('given high arg must be numeric')
+            assert_that(str(ex)).is_equal_to('given high arg must be numeric, but was <str>')
 
     def test_is_between_bad_arg_delta_failure(self):
         try:


### PR DESCRIPTION
This PR requests adds comparison support for the `datetime` types

 * `timedelta`
 * `date`
 * `time`

to the asserts

 * `is_greater_than`
 * `is_greater_than_or_equal_to`
 * `is_less_than`
 * `is_less_than_or_equal_to`
 * `is_between`.

Adding more supported types should be simple.

