### PR TITLE
added is_subset_of() for testing set comparison

### DIFF
--- a/assertpy/assertpy.py
+++ b/assertpy/assertpy.py
@@ -685,6 +685,17 @@ class AssertionBuilder(object):
                 self._err('Expected <%s> to not contain entry %s, but did.' % (self.val, e))
         return self
 
+### set assertions ###
+    def is_subset_of(self, superset):
+        """Asserts that val is a set and its items are contained within the set, 'superset'"""
+        if not isinstance(self.val, (set, frozenset)):
+            raise TypeError('val is not a set/frozenset')
+        if not isinstance(superset, (set, frozenset)):
+            raise TypeError('argument is not a set/frozenset')
+        if not self.val.issubset(superset):
+            self._err('Expected <%s> to be a subset of <%s>, but was not.' % (self.val, superset))
+        return self
+
 ### datetime assertions ###
     def is_before(self, other):
         """Asserts that val is a date and is before other date."""

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -1,0 +1,38 @@
+from assertpy import assert_that,fail
+
+class TestSet(object):
+
+    def test_val_type_error(self):
+        try:
+            assert_that(1).is_subset_of(set([1,2]))
+            fail('should have raised TypeError')
+        except TypeError:
+            pass
+
+    def test_arg_type_error(self):
+        try:
+            assert_that(set([])).is_subset_of(None)
+            fail('should have raised TypeError')
+        except TypeError:
+            pass
+
+    def test_val_edge_case(self):
+        assert_that(set()).is_subset_of(set([1,2,3]))
+
+    def test_arg_edge_case(self):
+        try:
+            assert_that(set([1,2,3])).is_subset_of(set())
+            fail('should have raised error')
+        except AssertionError as ex:
+            assert_that(str(ex)).is_equal_to('Expected <set([1, 2, 3])> to be a subset of <set([])>, but was not.')
+
+    def test_positive_normal_case(self):
+        assert_that(set([1])).is_subset_of(set([1,2,3]))
+
+    def test_negative_normal_case(self):
+        try:
+            assert_that(set([1,2,3])).is_subset_of(set([1]))
+            fail('should have raised error')
+        except AssertionError as ex:
+            assert_that(str(ex)).is_equal_to('Expected <set([1, 2, 3])> to be a subset of <set([1])>, but was not.')
+

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -24,7 +24,7 @@ class TestSet(object):
             assert_that(set([1,2,3])).is_subset_of(set())
             fail('should have raised error')
         except AssertionError as ex:
-            assert_that(str(ex)).is_equal_to('Expected <set([1, 2, 3])> to be a subset of <set([])>, but was not.')
+            assert_that(str(ex)).is_equal_to('Expected <%s> to be a subset of <%s>, but was not.' % (set([1,2,3]), set()))
 
     def test_positive_normal_case(self):
         assert_that(set([1])).is_subset_of(set([1,2,3]))
@@ -34,5 +34,5 @@ class TestSet(object):
             assert_that(set([1,2,3])).is_subset_of(set([1]))
             fail('should have raised error')
         except AssertionError as ex:
-            assert_that(str(ex)).is_equal_to('Expected <set([1, 2, 3])> to be a subset of <set([1])>, but was not.')
+            assert_that(str(ex)).is_equal_to('Expected <%s> to be a subset of <%s>, but was not.' % (set([1,2,3]), set([1])))
 


### PR DESCRIPTION
Currently, the way to test for subsets is a little roundabout:

```python
assert_that(set([1,2,3]).isssubset(set([1,2,3,4]))).is_true()
```

With this Pull Request, it's a bit cleaner:

```python
assert_that(set([1,2,3])).is_subset_of(set([1,2,3,4]))
```