### PR TITLE
is_type_of and is_instance_of support for ABC/Metaclass

### DIFF
--- a/assertpy/assertpy.py
+++ b/assertpy/assertpy.py
@@ -161,7 +161,7 @@ class AssertionBuilder(object):
 
     def is_type_of(self, some_type):
         """Asserts that val is of the given type."""
-        if type(some_type) is not type:
+        if type(some_type) is not type and not hasattr(some_type, '__metaclass__'):
             raise TypeError('given arg must be a type')
         if type(self.val) is not some_type:
             if hasattr(self.val, '__name__'):
@@ -175,16 +175,17 @@ class AssertionBuilder(object):
 
     def is_instance_of(self, some_class):
         """Asserts that val is an instance of the given class."""
-        if type(some_class) is not type:
+        try:
+            if not isinstance(self.val, some_class):
+                if hasattr(self.val, '__name__'):
+                    t = self.val.__name__
+                elif hasattr(self.val, '__class__'):
+                    t = self.val.__class__.__name__
+                else:
+                    t = 'unknown'
+                self._err('Expected <%s:%s> to be instance of class <%s>, but was not.' % (self.val, t, some_class.__name__))
+        except TypeError:
             raise TypeError('given arg must be a class')
-        if not isinstance(self.val, some_class):
-            if hasattr(self.val, '__name__'):
-                t = self.val.__name__
-            elif hasattr(self.val, '__class__'):
-                t = self.val.__class__.__name__
-            else:
-                t = 'unknown'
-            self._err('Expected <%s:%s> to be instance of class <%s>, but was not.' % (self.val, t, some_class.__name__))
         return self
 
     def is_length(self, length):
@@ -926,4 +927,3 @@ class AssertionBuilder(object):
         if check_getitem:
             if not hasattr(d, '__getitem__'):
                 raise TypeError('%s <%s> is not dict-like: missing [] accessor' % (name, type(d).__name__))
-

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -26,6 +26,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import abc
+
 from assertpy import assert_that
 
 class TestClass(object):
@@ -34,10 +36,14 @@ class TestClass(object):
         self.fred = Person('Fred','Smith')
         self.joe = Developer('Joe','Coder')
         self.people = [self.fred, self.joe]
+        self.car = Car()
+        self.truck = Truck()
 
     def test_is_type_of(self):
         assert_that(self.fred).is_type_of(Person)
         assert_that(self.joe).is_type_of(Developer)
+        assert_that(self.car).is_type_of(Car)
+        assert_that(self.truck).is_type_of(Truck)
 
     def test_is_instance_of(self):
         assert_that(self.fred).is_instance_of(Person)
@@ -46,6 +52,14 @@ class TestClass(object):
         assert_that(self.joe).is_instance_of(Developer)
         assert_that(self.joe).is_instance_of(Person)
         assert_that(self.joe).is_instance_of(object)
+
+        assert_that(self.car).is_instance_of(Car)
+        assert_that(self.car).is_instance_of(AbstractAutomobile)
+        assert_that(self.car).is_instance_of(object)
+
+        assert_that(self.truck).is_instance_of(Truck)
+        assert_that(self.truck).is_instance_of(AbstractAutomobile)
+        assert_that(self.truck).is_instance_of(object)
 
     def test_extract_attribute(self):
         assert_that(self.people).extracting('first_name').is_equal_to(['Fred','Joe'])
@@ -75,3 +89,22 @@ class Person(object):
 class Developer(Person):
     def say_hello(self):
         return '%s writes code.' % self.first_name
+
+class AbstractAutomobile(object):
+    __metaclass__ = abc.ABCMeta
+    def __init__(self):
+        pass
+
+    @abc.abstractproperty
+    def classification(self):
+        raise NotImplementedError('This method must be overridden')
+
+class Car(AbstractAutomobile):
+    @property
+    def classification(self):
+        return 'car'
+
+class Truck(AbstractAutomobile):
+    @property
+    def classification(self):
+        return 'truck'


### PR DESCRIPTION
Adding support for type and instance checking for Abstract Base Classes and other class definitions that leverage metaclasses.  Existing logic enforced that the passed in type or class reference was actually a type by check "if type(arg) is not type then raise".  This does not allow for using asserting type/instance checks against ABCs, collections.* (lots of ABCs), etc.  Added tests for abstract classes.

#### Checks that don't work:
```python
import collections
from assertpy import assert_that

def test_mapping():
    data = { 'a': 'b'}
    assert_that(data).is_instance_of(collections.Mapping)
```

#### Functions affected:
* `is_type_of`
* `is_instance_of`


#### Tests added:
tests/test_class.py

Defined 3 new classes, with a base implemented as an ABC.  Added assertion tests for `is_type_of()` and `is_instance_of()`.  All tests pass.
