### PR TITLE
add is_nan() and is_not_nan()

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ assert_that(0).is_instance_of(int)
 
 assert_that(0).is_zero()
 assert_that(1).is_not_zero()
+assert_that(math.nan).is_nan()
+assert_that(1).is_not_nan()
 assert_that(1).is_positive()
 assert_that(-1).is_negative()
 

--- a/assertpy/assertpy.py
+++ b/assertpy/assertpy.py
@@ -36,6 +36,7 @@ import datetime
 import numbers
 import collections
 import inspect
+import math
 from contextlib import contextmanager
 
 __version__ = '0.11'
@@ -387,6 +388,22 @@ class AssertionBuilder(object):
         if isinstance(self.val, numbers.Number) is False:
             raise TypeError('val is not numeric')
         return self.is_not_equal_to(0)
+
+    def is_nan(self):
+        """Asserts that val is numeric and equal to math.nan value."""
+        if isinstance(self.val, numbers.Number) is False:
+            raise TypeError('val is not numeric')
+        if not isinstance(self.val, numbers.Real) or not math.isnan(self.val):
+            self._err('Expected <%s> to be math.nan, but was not' % self.val)
+        return self
+
+    def is_not_nan(self):
+        """Asserts that val is numeric and not equal to math.nan value."""
+        if isinstance(self.val, numbers.Number) is False:
+            raise TypeError('val is not numeric')
+        if isinstance(self.val, numbers.Real) and math.isnan(self.val):
+            self._err('Expected not math.nan, but was')
+        return self
 
     def is_greater_than(self, other):
         """Asserts that val is numeric and is greater than other."""

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -25,6 +25,7 @@
 # ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import math
 
 from assertpy import assert_that,fail
 
@@ -66,6 +67,50 @@ class TestNumbers(object):
     def test_is_not_zero_bad_type_failure(self):
         try:
             assert_that('foo').is_not_zero()
+            fail('should have raised error')
+        except TypeError as ex:
+            assert_that(str(ex)).is_equal_to('val is not numeric')
+
+    def test_is_nan(self):
+        assert_that(math.nan).is_nan()
+        assert_that(float('nan')).is_nan()
+
+    def test_is_nan_failure(self):
+        try:
+            assert_that(1).is_nan()
+            fail('should have raised error')
+        except AssertionError as ex:
+            assert_that(str(ex)).is_equal_to('Expected <1> to be math.nan, but was not')
+
+    def test_is_nan_failure_with_complex(self):
+        try:
+            assert_that(1 + 1j).is_nan()
+            fail('should have raised error')
+        except AssertionError as ex:
+            assert_that(str(ex)).is_equal_to('Expected <(1+1j)> to be math.nan, but was not')
+
+    def test_is_nan_bad_type_failure(self):
+        try:
+            assert_that('foo').is_nan()
+            fail('should have raised error')
+        except TypeError as ex:
+            assert_that(str(ex)).is_equal_to('val is not numeric')
+
+    def test_is_not_nan(self):
+        assert_that(1).is_not_nan()
+        assert_that(1.0).is_not_nan()
+        assert_that(1 + 1j).is_not_nan()
+
+    def test_is_not_nan_failure(self):
+        try:
+            assert_that(math.nan).is_not_nan()
+            fail('should have raised error')
+        except AssertionError as ex:
+            assert_that(str(ex)).is_equal_to('Expected not math.nan, but was')
+
+    def test_is_not_nan_bad_type_failure(self):
+        try:
+            assert_that('foo').is_not_nan()
             fail('should have raised error')
         except TypeError as ex:
             assert_that(str(ex)).is_equal_to('val is not numeric')

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -54,8 +54,8 @@ def test_traceback():
 
             assert_that(frames[1][0]).ends_with('assertpy.py')
             assert_that(frames[1][1]).is_equal_to('is_equal_to')
-            assert_that(frames[1][2]).is_equal_to(159)
+            assert_that(frames[1][2]).is_equal_to(160)
 
             assert_that(frames[2][0]).ends_with('assertpy.py')
             assert_that(frames[2][1]).is_equal_to('_err')
-            assert_that(frames[2][2]).is_equal_to(970)
+            assert_that(frames[2][2]).is_equal_to(987)


### PR DESCRIPTION
In python `math.nan != math.nan` so it is not possible to use `is_equal_to()`.
I add `is_nan()` and `is_not_nan()` methods to handle it.
Hope I do it correctly.