### PR TITLE
assertions for NaN and Inf

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,6 @@ assert_that(0).is_instance_of(int)
 
 assert_that(0).is_zero()
 assert_that(1).is_not_zero()
-assert_that(math.nan).is_nan()
-assert_that(1).is_not_nan()
 assert_that(1).is_positive()
 assert_that(-1).is_negative()
 
@@ -161,6 +159,11 @@ assert_that(123.4).is_less_than(200.2)
 assert_that(123.4).is_less_than_or_equal_to(123.4)
 assert_that(123.4).is_between(100.1, 200.2)
 assert_that(123.4).is_close_to(123, 0.5)
+
+assert_that(float('NaN')).is_nan()
+assert_that(123.4).is_not_nan()
+assert_that(float('Inf')).is_inf()
+assert_that(123.4).is_not_inf()
 ```
 
 Of course, using `is_equal_to()` with a `float` value is just asking for trouble. You'll always want to use the assertions methods like `is_close_to()` and `is_between()`.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ assert_that(0).is_instance_of(int)
 
 assert_that(0).is_zero()
 assert_that(1).is_not_zero()
+assert_that(math.nan).is_nan()
+assert_that(1).is_not_nan()
 assert_that(1).is_positive()
 assert_that(-1).is_negative()
 

--- a/assertpy/assertpy.py
+++ b/assertpy/assertpy.py
@@ -377,32 +377,56 @@ class AssertionBuilder(object):
             return
         raise TypeError('ordering is not defined for type <%s>' % self_type.__name__)
 
-    def is_zero(self):
-        """Asserts that val is numeric and equal to zero."""
+    def _validate_number(self):
+        """Raise TypeError if val is not numeric."""
         if isinstance(self.val, numbers.Number) is False:
             raise TypeError('val is not numeric')
+
+    def _validate_real(self):
+        """Raise TypeError if val is not real number."""
+        if isinstance(self.val, numbers.Real) is False:
+            raise TypeError('val is not real number')
+
+    def is_zero(self):
+        """Asserts that val is numeric and equal to zero."""
+        self._validate_number()
         return self.is_equal_to(0)
 
     def is_not_zero(self):
         """Asserts that val is numeric and not equal to zero."""
-        if isinstance(self.val, numbers.Number) is False:
-            raise TypeError('val is not numeric')
+        self._validate_number()
         return self.is_not_equal_to(0)
 
     def is_nan(self):
-        """Asserts that val is numeric and equal to math.nan value."""
-        if isinstance(self.val, numbers.Number) is False:
-            raise TypeError('val is not numeric')
-        if not isinstance(self.val, numbers.Real) or not math.isnan(self.val):
-            self._err('Expected <%s> to be math.nan, but was not' % self.val)
+        """Asserts that val is real number and NaN (not a number)."""
+        self._validate_number()
+        self._validate_real()
+        if not math.isnan(self.val):
+            self._err('Expected <%s> to be <NaN>, but was not.' % self.val)
         return self
 
     def is_not_nan(self):
-        """Asserts that val is numeric and not equal to math.nan value."""
-        if isinstance(self.val, numbers.Number) is False:
-            raise TypeError('val is not numeric')
-        if isinstance(self.val, numbers.Real) and math.isnan(self.val):
-            self._err('Expected not math.nan, but was')
+        """Asserts that val is real number and not NaN (not a number)."""
+        self._validate_number()
+        self._validate_real()
+        if math.isnan(self.val):
+            self._err('Expected not <NaN>, but was.')
+        return self
+
+    def is_inf(self):
+        """Asserts that val is real number and Inf (infinity)."""
+        self._validate_number()
+        self._validate_real()
+        if not math.isinf(self.val):
+            self._err('Expected <%s> to be <Inf>, but was not.' % self.val)
+        return self
+
+    def is_not_inf(self):
+        """Asserts that val is real number and not Inf (infinity)."""
+        self._validate_number()
+        self._validate_real()
+        if math.isinf(self.val):
+            self._err('Expected not <Inf>, but was.')
         return self
 
     def is_greater_than(self, other):

--- a/assertpy/assertpy.py
+++ b/assertpy/assertpy.py
@@ -36,6 +36,7 @@ import datetime
 import numbers
 import collections
 import inspect
+import math
 from contextlib import contextmanager
 
 __version__ = '0.11'
@@ -387,6 +388,22 @@ class AssertionBuilder(object):
         if isinstance(self.val, numbers.Number) is False:
             raise TypeError('val is not numeric')
         return self.is_not_equal_to(0)
+
+    def is_nan(self):
+        """Asserts that val is numeric and equal to math.nan value."""
+        if isinstance(self.val, numbers.Number) is False:
+            raise TypeError('val is not numeric')
+        if not isinstance(self.val, numbers.Real) or not math.isnan(self.val):
+            self._err('Expected <%s> to be math.nan, but was not' % self.val)
+        return self
+
+    def is_not_nan(self):
+        """Asserts that val is numeric and not equal to math.nan value."""
+        if isinstance(self.val, numbers.Number) is False:
+            raise TypeError('val is not numeric')
+        if isinstance(self.val, numbers.Real) and math.isnan(self.val):
+            self._err('Expected not math.nan, but was')
+        return self
 
     def is_greater_than(self, other):
         """Asserts that val is numeric and is greater than other."""

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -72,22 +72,15 @@ class TestNumbers(object):
             assert_that(str(ex)).is_equal_to('val is not numeric')
 
     def test_is_nan(self):
-        assert_that(math.nan).is_nan()
-        assert_that(float('nan')).is_nan()
+        assert_that(float('NaN')).is_nan()
+        assert_that(float('Inf')-float('Inf')).is_nan()
 
     def test_is_nan_failure(self):
         try:
-            assert_that(1).is_nan()
+            assert_that(0).is_nan()
             fail('should have raised error')
         except AssertionError as ex:
-            assert_that(str(ex)).is_equal_to('Expected <1> to be math.nan, but was not')
-
-    def test_is_nan_failure_with_complex(self):
-        try:
-            assert_that(1 + 1j).is_nan()
-            fail('should have raised error')
-        except AssertionError as ex:
-            assert_that(str(ex)).is_equal_to('Expected <(1+1j)> to be math.nan, but was not')
+            assert_that(str(ex)).is_equal_to('Expected <0> to be <NaN>, but was not.')
 
     def test_is_nan_bad_type_failure(self):
         try:
@@ -96,17 +89,23 @@ class TestNumbers(object):
         except TypeError as ex:
             assert_that(str(ex)).is_equal_to('val is not numeric')
 
+    def test_is_nan_bad_type_failure_complex(self):
+        try:
+            assert_that(1 + 2j).is_nan()
+            fail('should have raised error')
+        except TypeError as ex:
+            assert_that(str(ex)).is_equal_to('val is not real number')
+
     def test_is_not_nan(self):
         assert_that(1).is_not_nan()
         assert_that(1.0).is_not_nan()
-        assert_that(1 + 1j).is_not_nan()
 
     def test_is_not_nan_failure(self):
         try:
-            assert_that(math.nan).is_not_nan()
+            assert_that(float('NaN')).is_not_nan()
             fail('should have raised error')
         except AssertionError as ex:
-            assert_that(str(ex)).is_equal_to('Expected not math.nan, but was')
+            assert_that(str(ex)).is_equal_to('Expected not <NaN>, but was.')
 
     def test_is_not_nan_bad_type_failure(self):
         try:
@@ -114,6 +113,63 @@ class TestNumbers(object):
             fail('should have raised error')
         except TypeError as ex:
             assert_that(str(ex)).is_equal_to('val is not numeric')
+
+    def test_is_not_nan_bad_type_failure_complex(self):
+        try:
+            assert_that(1 + 2j).is_not_nan()
+            fail('should have raised error')
+        except TypeError as ex:
+            assert_that(str(ex)).is_equal_to('val is not real number')
+
+    def test_is_inf(self):
+        assert_that(float('Inf')).is_inf()
+        assert_that(1e1000).is_inf()
+
+    def test_is_inf_failure(self):
+        try:
+            assert_that(0).is_inf()
+            fail('should have raised error')
+        except AssertionError as ex:
+            assert_that(str(ex)).is_equal_to('Expected <0> to be <Inf>, but was not.')
+
+    def test_is_inf_bad_type_failure(self):
+        try:
+            assert_that('foo').is_inf()
+            fail('should have raised error')
+        except TypeError as ex:
+            assert_that(str(ex)).is_equal_to('val is not numeric')
+
+    def test_is_inf_bad_type_failure_complex(self):
+        try:
+            assert_that(1 + 2j).is_inf()
+            fail('should have raised error')
+        except TypeError as ex:
+            assert_that(str(ex)).is_equal_to('val is not real number')
+
+    def test_is_not_inf(self):
+        assert_that(1).is_not_inf()
+        assert_that(123.456).is_not_inf()
+
+    def test_is_not_inf_failure(self):
+        try:
+            assert_that(float('Inf')).is_not_inf()
+            fail('should have raised error')
+        except AssertionError as ex:
+            assert_that(str(ex)).is_equal_to('Expected not <Inf>, but was.')
+
+    def test_is_not_inf_bad_type_failure(self):
+        try:
+            assert_that('foo').is_not_inf()
+            fail('should have raised error')
+        except TypeError as ex:
+            assert_that(str(ex)).is_equal_to('val is not numeric')
+
+    def test_is_not_inf_bad_type_failure_complex(self):
+        try:
+            assert_that(1 + 2j).is_not_inf()
+            fail('should have raised error')
+        except TypeError as ex:
+            assert_that(str(ex)).is_equal_to('val is not real number')
 
     def test_is_greater_than(self):
         assert_that(123).is_greater_than(100)

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -25,6 +25,7 @@
 # ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import math
 
 from assertpy import assert_that,fail
 
@@ -66,6 +67,50 @@ class TestNumbers(object):
     def test_is_not_zero_bad_type_failure(self):
         try:
             assert_that('foo').is_not_zero()
+            fail('should have raised error')
+        except TypeError as ex:
+            assert_that(str(ex)).is_equal_to('val is not numeric')
+
+    def test_is_nan(self):
+        assert_that(math.nan).is_nan()
+        assert_that(float('nan')).is_nan()
+
+    def test_is_nan_failure(self):
+        try:
+            assert_that(1).is_nan()
+            fail('should have raised error')
+        except AssertionError as ex:
+            assert_that(str(ex)).is_equal_to('Expected <1> to be math.nan, but was not')
+
+    def test_is_nan_failure_with_complex(self):
+        try:
+            assert_that(1 + 1j).is_nan()
+            fail('should have raised error')
+        except AssertionError as ex:
+            assert_that(str(ex)).is_equal_to('Expected <(1+1j)> to be math.nan, but was not')
+
+    def test_is_nan_bad_type_failure(self):
+        try:
+            assert_that('foo').is_nan()
+            fail('should have raised error')
+        except TypeError as ex:
+            assert_that(str(ex)).is_equal_to('val is not numeric')
+
+    def test_is_not_nan(self):
+        assert_that(1).is_not_nan()
+        assert_that(1.0).is_not_nan()
+        assert_that(1 + 1j).is_not_nan()
+
+    def test_is_not_nan_failure(self):
+        try:
+            assert_that(math.nan).is_not_nan()
+            fail('should have raised error')
+        except AssertionError as ex:
+            assert_that(str(ex)).is_equal_to('Expected not math.nan, but was')
+
+    def test_is_not_nan_bad_type_failure(self):
+        try:
+            assert_that('foo').is_not_nan()
             fail('should have raised error')
         except TypeError as ex:
             assert_that(str(ex)).is_equal_to('val is not numeric')

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -150,6 +150,11 @@ class TestReadme(object):
         assert_that(123.4).is_between(100.1, 200.2)
         assert_that(123.4).is_close_to(123, 0.5)
 
+        assert_that(float('NaN')).is_nan()
+        assert_that(123.4).is_not_nan()
+        assert_that(float('Inf')).is_inf()
+        assert_that(123.4).is_not_inf()
+
     def test_lists(self):
         assert_that([]).is_not_none()
         assert_that([]).is_empty()

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -58,4 +58,4 @@ def test_traceback():
 
             assert_that(frames[2][0]).ends_with('assertpy.py')
             assert_that(frames[2][1]).is_equal_to('_err')
-            assert_that(frames[2][2]).is_equal_to(987)
+            assert_that(frames[2][2]).is_greater_than(1000)

--- a/tests/test_traceback.py
+++ b/tests/test_traceback.py
@@ -54,8 +54,8 @@ def test_traceback():
 
             assert_that(frames[1][0]).ends_with('assertpy.py')
             assert_that(frames[1][1]).is_equal_to('is_equal_to')
-            assert_that(frames[1][2]).is_equal_to(159)
+            assert_that(frames[1][2]).is_equal_to(160)
 
             assert_that(frames[2][0]).ends_with('assertpy.py')
             assert_that(frames[2][1]).is_equal_to('_err')
-            assert_that(frames[2][2]).is_equal_to(970)
+            assert_that(frames[2][2]).is_equal_to(987)


### PR DESCRIPTION
Based off of #65, but this time just using `float('NaN')` and `math.isnan()` both of which should be >= 2.6 compatible.